### PR TITLE
Update to use darwinproject.ac.uk certificate

### DIFF
--- a/darwin-production/main.tf
+++ b/darwin-production/main.tf
@@ -13,6 +13,8 @@ module "base_architecture" {
   vpc_public_subnet_public_ip    = var.vpc_public_subnet_public_ip
   cloudwatch_log_group           = var.cloudwatch_log_group # TODO create log group
   vpc_cidr_block                 = var.vpc_cidr_block
+  acm_create_certificate         = false
+  acm_certificate_arn            = var.acm_certificate_arn
   tags                           = local.default_tags
 }
 
@@ -49,6 +51,8 @@ module "cudl-data-processing" {
   cloudfront_origin_path                    = var.cloudfront_origin_path
   cloudfront_error_response_page_path       = var.cloudfront_error_response_page_path
   cloudfront_viewer_request_function_arn    = aws_cloudfront_function.darwin.arn
+  acm_create_certificate                    = false
+  acm_certificate_arn                       = var.acm_certificate_arn_us-east-1
   providers = {
     aws.us-east-1 = aws.us-east-1
   }
@@ -95,6 +99,9 @@ module "solr" {
   allow_private_access                           = var.solr_use_service_discovery
   ingress_security_group_id                      = aws_security_group.solr.id
   efs_create_file_system                         = true
+  acm_create_certificate                         = false
+  acm_certificate_arn                            = var.acm_certificate_arn
+  acm_certificate_arn_us-east-1                  = var.acm_certificate_arn_us-east-1
   tags                                           = local.default_tags
   providers = {
     aws.us-east-1 = aws.us-east-1

--- a/darwin-production/terraform.tfvars
+++ b/darwin-production/terraform.tfvars
@@ -8,7 +8,7 @@ transcriptions-bucket-name   = "unused-cul-cudl-transcriptions"
 enhancements-bucket-name     = "unused-cul-cudl-data-enhancements"
 source-bucket-name           = "unused-cul-cudl-data-source"
 compressed-lambdas-directory = "compressed_lambdas"
-lambda-jar-bucket            = "cul-cudl.mvn.cudl.lib.cam.ac.uk"
+lambda-jar-bucket            = "cul-cudl.mvn.cudl.lib.cam.ac.uk" # can be removed?
 
 transform-lambda-bucket-sns-notifications = [
 
@@ -80,7 +80,7 @@ lambda-alias-name = "LIVE"
 
 releases-root-directory-path        = "/data"
 efs-name                            = "cudl-data-releases-efs"
-cloudfront_route53_zone_id          = "Z028489118FY8DBPA2P7Q"
+cloudfront_route53_zone_id          = "Z0526070386P5IAM6T0L4"
 cloudfront_distribution_name        = "production"
 cloudfront_origin_path              = "/www"
 cloudfront_error_response_page_path = "/404.html"
@@ -88,7 +88,7 @@ cloudfront_default_root_object      = "index.html"
 
 # Base Architecture
 cluster_name_suffix            = "darwin-ecs"
-registered_domain_name         = "darwinproject.link."
+registered_domain_name         = "darwinproject.ac.uk."
 asg_desired_capacity           = 1 # n = number of tasks
 asg_max_size                   = 1 # n + 1
 asg_allow_all_egress           = true
@@ -97,8 +97,10 @@ ec2_additional_userdata        = <<-EOF
 echo 1 > /proc/sys/vm/swappiness
 echo ECS_RESERVED_MEMORY=256 >> /etc/ecs/ecs.config
 EOF
-route53_zone_id_existing       = "Z028489118FY8DBPA2P7Q"
-route53_zone_force_destroy     = true
+route53_zone_id_existing       = "Z0526070386P5IAM6T0L4"
+route53_zone_force_destroy     = false
+acm_certificate_arn            = "arn:aws:acm:eu-west-1:330100528433:certificate/f8efa931-6cb9-4146-b025-a208b669a2b5"
+acm_certificate_arn_us-east-1  = "arn:aws:acm:us-east-1:330100528433:certificate/d62f5c3e-89dc-4b4d-abbf-eca9fdaa2b9f"
 alb_enable_deletion_protection = false
 alb_idle_timeout               = "900"
 vpc_cidr_block                 = "10.23.0.0/22" #1024 adresses
@@ -107,7 +109,7 @@ cloudwatch_log_group           = "/ecs/Darwin"
 
 # SOLR Worload
 solr_name_suffix       = "solr"
-solr_domain_name       = "darwin-production-search"
+solr_domain_name       = "search"
 solr_application_port  = 8983
 solr_target_group_port = 8081
 solr_ecr_repositories = {

--- a/darwin-production/variables.tf
+++ b/darwin-production/variables.tf
@@ -220,6 +220,16 @@ variable "route53_zone_force_destroy" {
   description = "Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone"
 }
 
+variable "acm_certificate_arn" {
+  type        = string
+  description = "ARN of an existing ACM certificate suitable for the Route 53 domain"
+}
+
+variable "acm_certificate_arn_us-east-1" {
+  type        = string
+  description = "ARN of an existing ACM certificate in us-east-1 region suitable for the Route 53 domain"
+}
+
 variable "alb_enable_deletion_protection" {
   type        = bool
   description = "Whether to enable deletion protection for the ALB"


### PR DESCRIPTION
- Create `acm_certificate_arn` and `acm_certificate_arn_us-east-1` variables
- Update values for `registered_domain_name` and `cloudfront_route53_zone_id` in `terraform.tfvars`
- Set `acm_create_certificate` argument to `false` in `base_architecture` module and pass in `acm_certificate_arn`
- Set `acm_create_certificate` argument to `false` in `cudl-data-processing` module and pass in `acm_certificate_arn`
- Set `acm_create_certificate` argument to `false` in `cudl-data-processing` module and pass in` acm_certificate_arn` and `acm_certificate_arn_us-east-1`
- Update `solr_domain_name` to `search`